### PR TITLE
`attrs.msd`: Add `pattern` and `sidebarInfoUrl`

### DIFF
--- a/app/modes/common.js
+++ b/app/modes/common.js
@@ -193,6 +193,8 @@ attrs.pos = {
 attrs.msd = {
     label: "msd",
     opts: settings.defaultOptions,
+    pattern: "<span class='msd_sidebar'><%=val%></span>",
+    sidebarInfoUrl: "markup/msdtags.html",
     extendedComponent: 'msd'
 };
 attrs.baseform = {


### PR DESCRIPTION
Add properties `pattern` and `sidebarInfoUrl` to `attrs.msd` in `modes/common.js` to implement value styling and info link for the standard `msd` attribute. This is required to retain the previous functionality after removing special handling of `msd` that did the same in the main repository (see pull request spraakbanken/korp-frontend#195).

As far as I can see, the result in the sidebar looks the same as before for standard `msd` attribute values.

However, as a result, the info link to the Swedish msd tags is no longer added to other attributes named `msd`, such as those in the Faroese corpus and the non-Swedish parts of parallel corpora, whose msd tagsets are different from that of Swedish. Neither are their values styled with class `msd_sidebar` any longer; if that is desired, an appropriate value for `pattern` would need to be specified in their definitions.